### PR TITLE
Add non JavaBeans dynamic Labels, Add imports in Config, Include Jetty Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
   - [Instrumentation Metadata](#instrumentation-metadata)
     - [Annotations](#annotations)
     - [Configuration](#configuration)
+      - [Class Imports](#class-imports)
     - [Metric Labels](#metric-labels)
       - [Dynamic Label Values](#dynamic-label-values)
     - [What we actually Transform](#what-we-actually-transform)
@@ -180,6 +181,29 @@ We write the configuration as follows
 Note the method signature is based on the method parameter types and return type. The parameter types are between the brackets `()` with the return type after. In this case we have no parameters and the return type is void which results in `()V`. [Here](http://journals.ecs.soton.ac.uk/java/tutorial/native1.1/implementing/method.html) is a good overview of Java method signature mappings.
 
 In previous versions we allowed the package name to be specified using `.` instead of the internal `/` separator. While this is still supported for the metrics configuration section, it is not supported anywhere else and should be updated to only have the `/` package separator. 
+
+
+#### Class Imports
+
+To simplify the metrics definition section of the configuration, we allow an imports section. Here we can define the fully qualified class names for any classes we use or re-use in the definitions. This includes method type descriptors.
+
+
+    imports:
+      - com/fleury/test/TestClass
+      - java/lang/Object
+      - java/lang/String
+
+    metrics:
+      TestClass.performSomeTask(LString;)V:
+        - type: Counted
+          name: taskx_total
+          doc: total invocations of task x
+          
+       TestClass.performSomeOtherTask(LString;)LObject;:
+         - type: Counted
+           name: tasky_total
+           doc: total invocations of task y
+
 
 
 ### Metric Labels

--- a/README.md
+++ b/README.md
@@ -189,16 +189,16 @@ Labels are a concept in some reporting systems that allow for multi-dimensional 
 
 #### Dynamic Label Values
 
-A powerful feature is the ability to set label values dynamic based on variables available on the method stack. Metric names cannot be dynamic. The way we specify dynamic label values is using the `${index}` syntax followed by the method argument index. The special value `$this` can be used to access the current instance reference in non static methods and non constructors (i.e. where `this.` is valid).
- 
-Note that we restrict the stack usage to the method arguments only. That is, we don't allow use of variables created within the method as that is a very fragile thing to do. The String representation as given by `String.valueOf()` of the parameter is used as the label value. That means for primitive types we perform boxing first and null objects will result in the String `"null"`. Argument indexes start at index `0` for non static methods and 1 for static methods. 
+A powerful feature is the ability to set label values dynamic based on variables available on the method stack. Metric names cannot be dynamic. The way we specify dynamic label values is using the `${index}` syntax followed by the method argument index. The special value `$this` can be used to access the current instance reference in non static methods. We prevent usage of `$this` in constructors to prevent initialisation leakage.
+
+Note that we restrict the stack usage to the method arguments only. That is, we don't allow use of variables created within the method as that is a very fragile thing to do. The String representation as given by `String.valueOf()` of the parameter is used as the label value. That means for primitive types we perform boxing first and null objects will result in the String `"null"`. Argument indexes start at index `0` up to the number of `args.length - 1` (i.e. array index syntax). We manage any special logic that occurs with the actual location on the stack due to non static methods (`this` is index `0` on the stack) and static methods (no `this`). Therefore you can always assume index `0` is the first method argument. 
 
 ```java
 @Counted (name = "service_total", labels = { "client:$0" })
 public void callService(String client) 
 ```
 
-Each time this method is invoked it will use the value of the `client` parameter as the metric label value. We also support accessing nested property values. For example, `($1.httpMethod)` where `$1` is the first method parameter and is e.g. of type `HttpRequest`. This means you are essentially doing `httpRequest.getHttpMethod().toString();`. This nesting can be arbitrarily deep. As we use `PropertyUtils` from the `commons-beanutils` library to perform the nested property reading, the method must obey the JavaBeans spec. It should be relatively easy to add support for new BeanIntrospectors to support non JavaBean nested lookup.
+Each time this method is invoked it will use the value of the `client` parameter as the metric label value. We also support accessing nested property values. For example, `($1.httpMethod)` where `$1` is the first method parameter and is e.g. of type `HttpRequest`. This means you are essentially doing `httpRequest.getHttpMethod().toString();`. This nesting can be arbitrarily deep. We use `PropertyUtils` from the `commons-beanutils` library to perform the nested property reading. Typically this means you can only use JavaBeans conforming properties, however, we have added a `GenericBeanIntrospector` which allows for accessing properties in methods like `name()` via e.g. `$1.name` etc. This gives better cross languages support.
 
 
 ### What we actually Transform

--- a/example-configurations/dropwizard.yaml
+++ b/example-configurations/dropwizard.yaml
@@ -1,0 +1,37 @@
+# same as jersey.yaml
+# tested on Dropwizard 1.x
+imports:
+  - com/fleury/resources/HelloWorldResource
+  - org/glassfish/jersey/server/ContainerRequest
+  - org/glassfish/jersey/server/ContainerResponse
+  - org/glassfish/jersey/message/internal/OutboundJaxrsResponse
+  - java/util/Optional
+  - java/lang/Object
+  - java/lang/String
+  - java/net/URI
+  - javax/servlet/http/HttpServletRequest
+  - javax/servlet/http/HttpServletResponse
+  - org/glassfish/jersey/internal/util/collection/Value
+  - org/glassfish/jersey/servlet/WebComponent
+
+
+
+metrics:
+
+  WebComponent.service(LURI;LURI;LHttpServletRequest;LHttpServletResponse;)LValue;:
+    - type: Timed
+      name: resource_latency
+      doc: Measuring http resource latencies
+      labels: ['path:$1.path', 'method:$2.method']
+
+  ContainerResponse.<init>(LContainerRequest;LOutboundJaxrsResponse;)V:
+    - type: Counted
+      name: http_status
+      doc: trying to count
+      labels: ['path:$0.requestUri.path', 'method:$0.method', 'status:$1.status']
+
+
+system:
+  jvm:
+    - gc
+    - memory

--- a/example-configurations/jersey.yaml
+++ b/example-configurations/jersey.yaml
@@ -1,0 +1,38 @@
+# Compatible & tested with Jersey 9.4
+# Should be compatible with 9.x range
+
+imports:
+  - com/fleury/resources/HelloWorldResource
+  - org/glassfish/jersey/server/ContainerRequest
+  - org/glassfish/jersey/server/ContainerResponse
+  - org/glassfish/jersey/message/internal/OutboundJaxrsResponse
+  - java/util/Optional
+  - java/lang/Object
+  - java/lang/String
+  - java/net/URI
+  - javax/servlet/http/HttpServletRequest
+  - javax/servlet/http/HttpServletResponse
+  - org/glassfish/jersey/internal/util/collection/Value
+  - org/glassfish/jersey/servlet/WebComponent
+
+
+
+metrics:
+
+  WebComponent.service(LURI;LURI;LHttpServletRequest;LHttpServletResponse;)LValue;:
+    - type: Timed
+      name: resource_latency
+      doc: Measuring http resource latencies
+      labels: ['path:$1.path', 'method:$2.method']
+
+  ContainerResponse.<init>(LContainerRequest;LOutboundJaxrsResponse;)V:
+    - type: Counted
+      name: http_status
+      doc: trying to count
+      labels: ['path:$0.requestUri.path', 'method:$0.method', 'status:$1.status']
+
+
+system:
+  jvm:
+    - gc
+    - memory

--- a/prometheus-metrics-agent-core/src/main/java/com/fleury/metrics/agent/Agent.java
+++ b/prometheus-metrics-agent-core/src/main/java/com/fleury/metrics/agent/Agent.java
@@ -21,7 +21,7 @@ public class Agent {
         initializeLogging(argParser.getLogConfigFilename());
 
         Configuration config = Configuration.createConfig(argParser.getConfigFilename());
-        PrometheusMetricSystemFactory.INSTANCE.init(config.getMetricSystemConfiguration());
+        PrometheusMetricSystemFactory.INSTANCE.init(config.getSystem());
 
         instrumentation.addTransformer(
                 new AnnotatedMetricClassTransformer(config),

--- a/prometheus-metrics-agent-core/src/main/java/com/fleury/metrics/agent/config/Configuration.java
+++ b/prometheus-metrics-agent-core/src/main/java/com/fleury/metrics/agent/config/Configuration.java
@@ -3,6 +3,7 @@ package com.fleury.metrics.agent.config;
 import static java.util.logging.Level.FINE;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.DeserializationFeature;
@@ -18,11 +19,15 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.logging.Logger;
+import org.objectweb.asm.Type;
 
 /**
  *
@@ -51,16 +56,14 @@ public class Configuration {
 
     public static Configuration createConfig(String filename) {
         if (filename == null) {
-            return new Configuration();
+            return emptyConfiguration();
         }
 
+        LOGGER.log(FINE, "Found config file: {0}", filename);
+
         try {
-            LOGGER.log(FINE, "Found config file: {0}", filename);
-            Configuration configuration = createConfig(new FileInputStream(filename));
-            LOGGER.log(FINE, "Created config: {0}", configuration);
-            return configuration;
-        }
-        catch (FileNotFoundException e) {
+            return createConfig(new FileInputStream(filename));
+        } catch (FileNotFoundException e) {
             throw new RuntimeException(e);
         }
     }
@@ -68,31 +71,81 @@ public class Configuration {
     public static Configuration createConfig(InputStream is) {
         try {
             return MAPPER.readValue(is, Configuration.class);
-        }
-        catch (Exception e) {
+        } catch (Exception e) {
             throw new RuntimeException(e);
+        } finally {
+            try {
+                is.close();
+            } catch (IOException e) {}
         }
     }
 
-    @JsonProperty("metrics")
-    private Map<Key, List<Metric>> metrics = Collections.emptyMap();
-
-    @JsonProperty("system")
-    private Map<String, Object> metricSystemConfiguration = Collections.emptyMap();
-
-    @JsonProperty("whiteList")
-    private List<String> whiteList = Collections.emptyList();
-
-    @JsonProperty("blackList")
-    private List<String> blackList = Collections.emptyList();
-
-    public Configuration() {
-        this(new HashMap<Key, List<Metric>>());
+    public static Configuration emptyConfiguration() {
+        return new Configuration();
     }
 
-    public Configuration(Map<Key, List<Metric>> metrics) {
-        this.metrics = metrics;
+    private final Set<String> imports;
+    private final Map<Key, List<Metric>> metrics;
+    private final Map<String, Object> system;
+    private final List<String> whiteList;
+    private final List<String> blackList;
+
+    private Configuration() {
+        this(new HashMap<Key, List<Metric>>(),
+                Collections.<String>emptySet(),
+                Collections.<String, Object>emptyMap(),
+                Collections.<String>emptyList(),
+                Collections.<String>emptyList());
     }
+
+    @JsonCreator
+    public Configuration(
+            @JsonProperty("metrics") Map<Key, List<Metric>> metrics,
+            @JsonProperty("imports") Set<String> imports,
+            @JsonProperty("system") Map<String, Object> system,
+            @JsonProperty("whiteList") List<String> whiteList,
+            @JsonProperty("blackList") List<String> blackList) {
+
+        this.imports = imports == null ? Collections.<String>emptySet() : imports;
+
+        this.metrics = metrics == null ?
+                new HashMap<Key, List<Metric>>() :
+                processClassImports(metrics, this.imports); //ensure fqn expanded from imports
+
+        this.system = system == null ? Collections.<String, Object>emptyMap() : system;
+        this.whiteList = whiteList == null ? Collections.<String>emptyList() : whiteList;
+        this.blackList = blackList == null ? Collections.<String>emptyList() : blackList;
+    }
+
+    private static Map<Key, List<Metric>> processClassImports(Map<Key, List<Metric>> metrics, Set<String> imports) {
+        Map<String, String> expandedKeys = fqnToMap(imports);
+
+        Map<Key, List<Metric>> processed = new HashMap<Key, List<Metric>>();
+        for (Map.Entry<Key, List<Metric>> entry : metrics.entrySet()) {
+            Key key = entry.getKey();
+
+            String fqn = expandedKeys.get(key.getClassName());
+            if (fqn == null) {
+                fqn = key.getClassName();
+            }
+
+            String descriptor = key.descriptor;
+
+            Map<String, String> fqnMap = getMethodDescriptorFQNMap(descriptor);
+            for (String className : fqnMap.keySet()) {
+                if (expandedKeys.containsKey(className)) {
+                    descriptor = descriptor.replaceAll(className, expandedKeys.get(className));
+                }
+            }
+
+            key = new Key(fqn, key.getMethod(), descriptor);
+
+            processed.put(key, entry.getValue());
+        }
+
+        return processed;
+    }
+
 
     public boolean isMetric(String className) {
         for (Key key : metrics.keySet()) {
@@ -117,17 +170,24 @@ public class Configuration {
         return found;
     }
 
-    public List<Metric> findMetrics(String className, String method) {
-        Key key = new Key(className, method);
+    public List<Metric> findMetrics(String className, String method, String descriptor) {
+        Key key = new Key(className, method, descriptor);
         return metrics.containsKey(key) ? metrics.get(key) : Collections.<Metric>emptyList();
     }
 
-    public Map<Key, List<Metric>> getMetrics() {
-        return metrics;
+    public void addMetric(Key key, Metric metric) {
+        List<Metric> keyMetrics = metrics.get(key);
+
+        if (keyMetrics == null) {
+            keyMetrics = new ArrayList<Metric>();
+            metrics.put(key, keyMetrics);
+        }
+
+        keyMetrics.add(metric);
     }
-    
-    public Map<String, Object> getMetricSystemConfiguration() {
-        return metricSystemConfiguration;
+
+    public Map<String, Object> getSystem() {
+        return system;
     }
 
     public List<String> getWhiteList() {
@@ -136,14 +196,6 @@ public class Configuration {
 
     public List<String> getBlackList() {
         return blackList;
-    }
-
-    public void setWhiteList(List<String> whiteList) {
-        this.whiteList = whiteList;
-    }
-
-    public void setBlackList(List<String> blackList) {
-        this.blackList = blackList;
     }
 
     public boolean isWhiteListed(String className) {
@@ -174,20 +226,48 @@ public class Configuration {
     public String toString() {
         return "Configuration{" +
                 "metrics=" + metrics +
-                ", metricSystemConfiguration=" + metricSystemConfiguration +
+                ", system=" + system +
                 ", whiteList=" + whiteList +
                 ", blackList=" + blackList +
                 '}';
+    }
+
+    public static Map<String, String> fqnToMap(Collection<String> classNames) {
+        Map<String, String> expandedKeys = new HashMap<String, String>();
+        for (String fqn : classNames) {
+            String className = fqn.substring(fqn.lastIndexOf("/") + 1, fqn.length());
+            expandedKeys.put(className, fqn);
+        }
+
+        return expandedKeys;
+    }
+
+    public static Map<String, String> getMethodDescriptorFQNMap(String descriptor) {
+        Type type = Type.getMethodType(descriptor);
+
+        Set<String> classes = new HashSet<String>();
+        classes.add(type.getReturnType().getClassName());
+
+        Type[] arguments = type.getArgumentTypes();
+        if (arguments != null) {
+            for (Type arg : arguments) {
+                classes.add(arg.getClassName());
+            }
+        }
+
+        return fqnToMap(classes);
     }
 
     public static class Key {
 
         private final String className;
         private final String method;
+        private final String descriptor;
 
-        public Key(String className, String method) {
+        public Key(String className, String method, String descriptor) {
             this.className = className;
             this.method = method;
+            this.descriptor = descriptor;
         }
 
         public String getClassName() {
@@ -198,11 +278,16 @@ public class Configuration {
             return method;
         }
 
+        public String getDescriptor() {
+            return descriptor;
+        }
+
         @Override
         public int hashCode() {
             int hash = 3;
             hash = 29 * hash + (this.className != null ? this.className.hashCode() : 0);
             hash = 29 * hash + (this.method != null ? this.method.hashCode() : 0);
+            hash = 29 * hash + (this.descriptor != null ? this.descriptor.hashCode() : 0);
             return hash;
         }
 
@@ -221,6 +306,9 @@ public class Configuration {
             if ((this.method == null) ? (other.method != null) : !this.method.equals(other.method)) {
                 return false;
             }
+            if ((this.descriptor == null) ? (other.descriptor != null) : !this.descriptor.equals(other.descriptor)) {
+                return false;
+            }
             return true;
         }
 
@@ -229,6 +317,7 @@ public class Configuration {
             return "Key{" +
                     "className='" + className + '\'' +
                     ", method='" + method + '\'' +
+                    ", desc='" + descriptor + '\'' +
                     '}';
         }
     }
@@ -238,9 +327,11 @@ public class Configuration {
         @Override
         public Object deserializeKey(final String key, final DeserializationContext ctxt) throws IOException {
             String className = dotToSlash(key.substring(0, key.lastIndexOf(".")));
-            String methodName = key.substring(key.lastIndexOf(".") + 1, key.length());
+            String methodName = key.substring(key.lastIndexOf(".") + 1, key.indexOf("("));
 
-            return new Key(className, methodName);
+            String desc = key.substring(key.indexOf("("), key.length());
+
+            return new Key(className, methodName, desc);
         }
     }
 

--- a/prometheus-metrics-agent-core/src/main/java/com/fleury/metrics/agent/introspector/GenericClassIntrospector.java
+++ b/prometheus-metrics-agent-core/src/main/java/com/fleury/metrics/agent/introspector/GenericClassIntrospector.java
@@ -1,0 +1,41 @@
+package com.fleury.metrics.agent.introspector;
+
+import static java.util.logging.Level.FINE;
+
+import java.beans.IntrospectionException;
+import java.beans.PropertyDescriptor;
+import java.lang.reflect.Method;
+import java.util.logging.Logger;
+import org.apache.commons.beanutils.BeanIntrospector;
+import org.apache.commons.beanutils.IntrospectionContext;
+
+public class GenericClassIntrospector implements BeanIntrospector {
+
+    private static final Logger LOGGER = Logger.getLogger(GenericClassIntrospector.class.getName());
+
+    @Override
+    public void introspect(IntrospectionContext icontext) {
+
+        for (final Method m : icontext.getTargetClass().getMethods()) {
+
+            if (isValidValueMethod(m)) {
+                try {
+                    icontext.addPropertyDescriptor(new PropertyDescriptor(m.getName(), m, null));
+                } catch (final IntrospectionException e) {
+                    LOGGER.info("Error when creating PropertyDescriptor for " + m + "! Ignoring this property.");
+                    LOGGER.log(FINE, "Exception is:", e);
+                }
+            }
+        }
+    }
+
+    private boolean isValidValueMethod(Method m) {
+        //e.g. name()
+        return m.getParameterTypes().length == 0 &&
+                !m.getReturnType().equals(Void.TYPE) &&
+                !m.getName().startsWith("get") && //already obtained via DefaultBeanIntrospector
+                !m.getName().startsWith("wait") &&
+                !m.getName().equals("hashCode") &&
+                !m.getName().equals("toString");
+    }
+}

--- a/prometheus-metrics-agent-core/src/main/java/com/fleury/metrics/agent/transformer/asm/AnnotationMethodVisitor.java
+++ b/prometheus-metrics-agent-core/src/main/java/com/fleury/metrics/agent/transformer/asm/AnnotationMethodVisitor.java
@@ -34,7 +34,7 @@ public class AnnotationMethodVisitor extends MethodVisitor {
         MetricType metricType = checkSignature(desc);
 
         if (metricType != null) {
-            Configuration.Key key = new Configuration.Key(className, methodName + methodDesc);
+            Configuration.Key key = new Configuration.Key(className, methodName, methodDesc);
 
             return new MetricAnnotationAttributeVisitor(super.visitAnnotation(desc, visible), metricType, config, key);
         }

--- a/prometheus-metrics-agent-core/src/main/java/com/fleury/metrics/agent/transformer/asm/MetricAnnotationAttributeVisitor.java
+++ b/prometheus-metrics-agent-core/src/main/java/com/fleury/metrics/agent/transformer/asm/MetricAnnotationAttributeVisitor.java
@@ -75,13 +75,6 @@ public class MetricAnnotationAttributeVisitor extends AnnotationVisitor {
     public void visitEnd() {
         super.visitEnd();
 
-        List<Metric> metrics = config.getMetrics().get(metricKey);
-
-        if (metrics == null) {
-            metrics = new ArrayList<Metric>();
-            config.getMetrics().put(metricKey, metrics);
-        }
-
-        metrics.add(metricBuilder.createMetric());
+        config.addMetric(metricKey, metricBuilder.createMetric());
     }
 }

--- a/prometheus-metrics-agent-core/src/main/java/com/fleury/metrics/agent/transformer/asm/MetricClassVisitor.java
+++ b/prometheus-metrics-agent-core/src/main/java/com/fleury/metrics/agent/transformer/asm/MetricClassVisitor.java
@@ -62,7 +62,7 @@ public class MetricClassVisitor extends ClassVisitor {
 
         // instrument the method
         if (!isInterface && !isSyntheticMethod && mv != null) {
-            List<Metric> metadata = config.findMetrics(className, name + desc);
+            List<Metric> metadata = config.findMetrics(className, name, desc);
 
             mv = new MetricAdapter(mv, className, access, name, desc, metadata);
             mv = new JSRInlinerAdapter(mv, access, name, desc, signature, exceptions);

--- a/prometheus-metrics-agent-core/src/main/java/com/fleury/metrics/agent/transformer/asm/injectors/AbstractInjector.java
+++ b/prometheus-metrics-agent-core/src/main/java/com/fleury/metrics/agent/transformer/asm/injectors/AbstractInjector.java
@@ -7,6 +7,7 @@ import static com.fleury.metrics.agent.model.LabelUtil.isTemplatedLabelValue;
 import static com.fleury.metrics.agent.model.LabelUtil.isThis;
 import static com.fleury.metrics.agent.transformer.asm.util.CollectionUtil.isNotEmpty;
 
+import com.fleury.metrics.agent.introspector.GenericClassIntrospector;
 import com.fleury.metrics.agent.model.LabelUtil;
 import com.fleury.metrics.agent.model.Metric;
 import com.fleury.metrics.agent.reporter.PrometheusMetricSystem;
@@ -24,6 +25,10 @@ import org.objectweb.asm.commons.AdviceAdapter;
 public abstract class AbstractInjector implements Injector, Opcodes {
 
     public static final String METRIC_REPORTER_CLASSNAME = Type.getInternalName(PrometheusMetricSystem.class);
+
+    static {
+        PropertyUtils.addBeanIntrospector(new GenericClassIntrospector());
+    }
 
     protected final AdviceAdapter aa;
     protected final Type[] argTypes;

--- a/prometheus-metrics-agent-core/src/test/java/com/fleury/metrics/agent/config/ConfigurationTest.java
+++ b/prometheus-metrics-agent-core/src/test/java/com/fleury/metrics/agent/config/ConfigurationTest.java
@@ -1,10 +1,12 @@
 package com.fleury.metrics.agent.config;
 
 import static com.fleury.metrics.agent.model.MetricType.Counted;
+import static com.fleury.metrics.agent.model.MetricType.Timed;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 
 import com.fleury.metrics.agent.model.Metric;
+import com.fleury.metrics.agent.model.MetricType;
 import java.io.InputStream;
 import java.util.Arrays;
 import java.util.List;
@@ -17,20 +19,29 @@ import org.junit.Test;
 public class ConfigurationTest {
 
     @Test
-    public void testParseMetricsConfig() {
+    public void testParseAndExpandMetricImports() {
         InputStream is = this.getClass().getResourceAsStream("/config/sample.yaml");
         Configuration config = Configuration.createConfig(is);
 
-        assertTrue(!config.getMetrics().isEmpty());
+        assertFalse(config.findMetrics("com/fleury/sample/Engine").isEmpty());
 
-        List<Metric> metrics = config.findMetrics("com/fleury/sample/Engine", "sampleMethod(I)J");
+        List<Metric> metrics = config.findMetrics("com/fleury/sample/Engine", "sampleMethod", "(I)J");
         assertEquals(2, metrics.size());
 
-        Metric metric = metrics.get(0);
-        assertEquals(Counted, metric.getType());
-        assertEquals("count", metric.getName());
-        assertEquals("trying to count", metric.getDoc());
-        assertEquals(Arrays.asList("name1:value1", "name2:value2"), metric.getLabels());
+        assertMetricDetails(metrics.get(0), Counted, "count", "trying to count", Arrays.asList("name1:value1", "name2:value2"));
+        assertMetricDetails(metrics.get(1), Timed, "timer", "trying to time", Arrays.asList("name1:value1", "name2:value2"));
+
+        metrics = config.findMetrics("com/test/Special", "sampleMethod", "(Ljava/lang/String;)J");
+        assertEquals(1, metrics.size());
+
+        assertMetricDetails(metrics.get(0), Counted, "count", "trying to count", null);
+    }
+
+    private void assertMetricDetails(Metric metric, MetricType type, String name, String doc, List<String> labels) {
+        assertEquals(type, metric.getType());
+        assertEquals(name, metric.getName());
+        assertEquals(doc, metric.getDoc());
+        assertEquals(labels, metric.getLabels());
     }
 
     @Test
@@ -38,7 +49,8 @@ public class ConfigurationTest {
         InputStream is = this.getClass().getResourceAsStream("/config/sample.yaml");
         Configuration config = Configuration.createConfig(is);
 
-        assertTrue(!config.getMetricSystemConfiguration().isEmpty());
+        assertFalse(config.getSystem().isEmpty());
     }
+
 
 }

--- a/prometheus-metrics-agent-core/src/test/java/com/fleury/metrics/agent/transformer/asm/injectors/BaseMetricTest.java
+++ b/prometheus-metrics-agent-core/src/test/java/com/fleury/metrics/agent/transformer/asm/injectors/BaseMetricTest.java
@@ -1,6 +1,7 @@
 package com.fleury.metrics.agent.transformer.asm.injectors;
 
 import static com.fleury.metrics.agent.config.Configuration.dotToSlash;
+import static com.fleury.metrics.agent.config.Configuration.emptyConfiguration;
 
 import com.fleury.metrics.agent.config.Configuration;
 import com.fleury.metrics.agent.reporter.TestMetricReader;
@@ -40,7 +41,7 @@ public abstract class BaseMetricTest {
     }
 
     protected <T> Class<T> execute(Class<T> clazz) throws Exception {
-        return execute(clazz, new Configuration());
+        return execute(clazz, emptyConfiguration());
     }
 
     protected <T> Class<T> execute(Class<T> clazz, Configuration config) throws Exception {

--- a/prometheus-metrics-agent-core/src/test/java/com/fleury/metrics/agent/transformer/asm/injectors/CounterInjectorTest.java
+++ b/prometheus-metrics-agent-core/src/test/java/com/fleury/metrics/agent/transformer/asm/injectors/CounterInjectorTest.java
@@ -1,5 +1,6 @@
 package com.fleury.metrics.agent.transformer.asm.injectors;
 
+import static com.fleury.metrics.agent.config.Configuration.emptyConfiguration;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -8,9 +9,6 @@ import com.fleury.metrics.agent.config.Configuration;
 import com.fleury.metrics.agent.model.Metric;
 import com.fleury.metrics.agent.model.MetricType;
 import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import org.junit.Test;
 import org.objectweb.asm.Type;
 
@@ -38,12 +36,11 @@ public class CounterInjectorTest extends BaseMetricTest {
                 .createMetric();
 
         Configuration.Key key = new Configuration.Key(
-                Type.getType(ConfigurationCountedConstructorClass.class).getInternalName(),
-                "<init>()V");
-        Map<Configuration.Key, List<Metric>> mConfig = new HashMap<Configuration.Key, List<Metric>>();
-        mConfig.put(key, Arrays.asList(meta));
+                Type.getInternalName(ConfigurationCountedConstructorClass.class),
+                "<init>", "()V");
 
-        Configuration config = new Configuration(mConfig);
+        Configuration config = emptyConfiguration();
+        config.addMetric(key, meta);
 
         Class<ConfigurationCountedConstructorClass> clazz = execute(ConfigurationCountedConstructorClass.class, config);
 

--- a/prometheus-metrics-agent-core/src/test/java/com/fleury/metrics/agent/transformer/asm/injectors/LabelsTest.java
+++ b/prometheus-metrics-agent-core/src/test/java/com/fleury/metrics/agent/transformer/asm/injectors/LabelsTest.java
@@ -54,6 +54,12 @@ public class LabelsTest extends BaseMetricTest {
                 new Object[]{new CountedConstructorWithDynamicNestedLabelValueClass.Nester()}, new String[]{"hello"});
     }
 
+    @Test
+    public void shouldCountConstructorInvocationWithDynamicNestedNonJavaBeanValue() throws Exception {
+        testInvocationWithArgs(CountedConstructorWithDynamicNestedNonJavaBeanLabelValueClass.class,
+                new Object[]{new CountedConstructorWithDynamicNestedNonJavaBeanLabelValueClass.Nester()}, new String[]{"hello"});
+    }
+
     @Test(expected = IllegalArgumentException.class)
     public void shouldThrowExceptionWhenInvalidParamIndexLabelValue() throws Exception {
         testInvocationWithArgs(CountedConstructorWithInvalidParamIndexLabelValueClass.class,
@@ -164,6 +170,20 @@ public class LabelsTest extends BaseMetricTest {
 
         @Counted(name = "constructor", labels = {"name1:$0.hello"})
         public CountedConstructorWithDynamicNestedLabelValueClass(Nester nester) {
+            BaseMetricTest.performBasicTask();
+        }
+    }
+
+    public static class CountedConstructorWithDynamicNestedNonJavaBeanLabelValueClass {
+
+        public static class Nester {
+            public String hello() {
+                return "hello";
+            }
+        }
+
+        @Counted(name = "constructor", labels = {"name1:$0.hello"})
+        public CountedConstructorWithDynamicNestedNonJavaBeanLabelValueClass(Nester nester) {
             BaseMetricTest.performBasicTask();
         }
     }

--- a/prometheus-metrics-agent-core/src/test/java/com/fleury/metrics/agent/transformer/asm/injectors/WhiteBlackListTest.java
+++ b/prometheus-metrics-agent-core/src/test/java/com/fleury/metrics/agent/transformer/asm/injectors/WhiteBlackListTest.java
@@ -1,6 +1,7 @@
 package com.fleury.metrics.agent.transformer.asm.injectors;
 
 import static com.fleury.metrics.agent.config.Configuration.dotToSlash;
+import static com.fleury.metrics.agent.config.Configuration.emptyConfiguration;
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 
@@ -13,9 +14,8 @@ public class WhiteBlackListTest extends BaseMetricTest {
 
     @Test
     public void allowWhiteListed() throws Exception {
-        Configuration config = new Configuration();
         List<String> whiteList = asList(dotToSlash(CountedMethodClass.class.getName()));
-        config.setWhiteList(whiteList);
+        Configuration config = new Configuration(null, null, null, whiteList, null);
 
         Class<CountedMethodClass> clazz = execute(CountedMethodClass.class, config);
 
@@ -28,9 +28,8 @@ public class WhiteBlackListTest extends BaseMetricTest {
 
     @Test
     public void ignoreBlackListed() throws Exception {
-        Configuration config = new Configuration();
         List<String> blackList = asList(dotToSlash(CountedMethodClass.class.getName()));
-        config.setBlackList(blackList);
+        Configuration config = new Configuration(null, null, null, null, blackList);
 
         Class<CountedMethodClass> clazz = execute(CountedMethodClass.class, config);
 

--- a/prometheus-metrics-agent-core/src/test/resources/config/sample.yaml
+++ b/prometheus-metrics-agent-core/src/test/resources/config/sample.yaml
@@ -1,14 +1,20 @@
 
+imports:
+  - com/fleury/sample/Engine
+  - java/lang/Object
+  - java/lang/String
+
 # key is class name, method name and method signature
 # {class}:{method}{signature}
 
 # labels are of the format
 # {name}:{value}
-# {value} can be a constant or it can be templated based on the method stack of 
+# {value} can be a constant or it can be templated based on the method stack of
 # variables/fields accessible via objects on the stack
 
 metrics:
-  com.fleury.sample.Engine.sampleMethod(I)J:
+  # the import above for com/fleury/sample/Engine ensures I can use className alone here
+  Engine.sampleMethod(I)J:
     - type: Counted
       name: count
       doc: trying to count
@@ -17,9 +23,15 @@ metrics:
       name: timer
       doc: trying to time
       labels: ['name1:value1', 'name2:value2']
-       
 
+  com/test/Special.sampleMethod(LString;)J:
+      - type: Counted
+        name: count
+        doc: trying to count
 
 system:
-    key1: value1
+  httpPort: 9090
+  jvm:
+    - gc
+    - memory
     


### PR DESCRIPTION
With nested property values for dynamic labels, this change supports more than just JavaBeans syntax provided by commons-beanutils. This is particularly useful for non Java languages where the getPropertyName isn't always followed and the method might just be propertyName. 