### PR TITLE
Add JmxCollector to scrape JMX Metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@
     - [Supported Languages](#supported-languages)
   - [Agent Configuration](#agent-configuration)
     - [Prometheus Configuration](#prometheus-configuration)
+      - [JVM Metrics](#jvm-metrics)
+      - [JMX Metrics](#jmx-metrics)
     - [Agent Reporting](#agent-reporting)
     - [Black & White Lists](#black-and-white-lists)
     - [Logger Configuration](#logger-configuration)
@@ -257,6 +259,7 @@ You can do the same for Kotlin, Clojure and any other JVM language. Be aware tha
 
 ### Prometheus Configuration
 
+#### JVM Metrics
 Prometheus supports adding JVM level metrics information obtained from the JVM via MBeans for 
 
 - gc
@@ -270,6 +273,24 @@ To enable each, simply add the metrics you want to a `jvm` property in the `syst
         jvm:
            - gc
            - memory
+
+#### JMX Metrics
+We also include the Prometheus JmxCollector from the [JmxExporter](https://github.com/prometheus/jmx_exporter) project in this agent as it allows collecting other JMX metrics from the JVM one might want to. To enable the JmxCollector simply add a `jmx` section in the system configuration and add configuration as shown in the [JmxExporter](https://github.com/prometheus/jmx_exporter) project. The configuration is passed straight through to the JmxCollector constructor.
+
+    system:
+        jmx:
+            startDelaySeconds: 0
+            whitelistObjectNames: ["org.apache.cassandra.metrics:*"]
+            blacklistObjectNames: ["org.apache.cassandra.metrics:type=ColumnFamily,*"]
+            rules:
+              - pattern: 'org.apache.cassandra.metrics<type=(\w+), name=(\w+)><>Value: (\d+)'
+                name: cassandra_$1_$2
+                value: $3
+                valueFactor: 0.001
+                labels: {}
+                help: "Cassandra metric $1 $2"
+                type: GAUGE
+                attrNameSnakeCase: false
 
 
 ### Agent Reporting

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,7 @@
         <dropwizard.metrics>3.2.5</dropwizard.metrics>
         <asm.version>5.1</asm.version>
         <prometheus.version>0.0.26</prometheus.version>
+        <prometheus.jmx.version>0.10</prometheus.jmx.version>
         <jackson.version>2.4.0</jackson.version>
         <commons.beanutils.version>1.9.3</commons.beanutils.version>
 

--- a/prometheus-metrics-agent-core/pom.xml
+++ b/prometheus-metrics-agent-core/pom.xml
@@ -30,6 +30,12 @@
         </dependency>
 
         <dependency>
+            <groupId>io.prometheus.jmx</groupId>
+            <artifactId>collector</artifactId>
+            <version>${prometheus.jmx.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>io.prometheus</groupId>
             <artifactId>simpleclient_httpserver</artifactId>
             <version>${prometheus.version}</version>

--- a/prometheus-metrics-agent-core/src/main/java/com/fleury/metrics/agent/Agent.java
+++ b/prometheus-metrics-agent-core/src/main/java/com/fleury/metrics/agent/Agent.java
@@ -26,17 +26,5 @@ public class Agent {
         instrumentation.addTransformer(
                 new AnnotatedMetricClassTransformer(config),
                 instrumentation.isRetransformClassesSupported());
-
-        startDefaultMetricEndpoint();
-    }
-
-    private static void startDefaultMetricEndpoint() {
-        //start in background thread so we don't delay application startup
-        new Thread(new Runnable() {
-            @Override
-            public void run() {
-                PrometheusMetricSystemFactory.INSTANCE.get().startDefaultEndpoint();
-            }
-        }).start();
     }
 }

--- a/prometheus-metrics-agent-core/src/main/java/com/fleury/metrics/agent/config/Configuration.java
+++ b/prometheus-metrics-agent-core/src/main/java/com/fleury/metrics/agent/config/Configuration.java
@@ -46,7 +46,7 @@ public class Configuration {
         return ("metrics$" + metric.getName()+"$"+metric.getType()).toUpperCase();
     }
 
-    private final static ObjectMapper MAPPER = new ObjectMapper(new YAMLFactory()) {
+    public final static ObjectMapper YAML_MAPPER = new ObjectMapper(new YAMLFactory()) {
         {
             configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
             configure(JsonParser.Feature.STRICT_DUPLICATE_DETECTION, true);
@@ -72,7 +72,7 @@ public class Configuration {
 
     public static Configuration createConfig(InputStream is) {
         try {
-            return MAPPER.readValue(is, Configuration.class);
+            return YAML_MAPPER.readValue(is, Configuration.class);
         } catch (Exception e) {
             throw new RuntimeException(e);
         } finally {

--- a/prometheus-metrics-agent-core/src/main/java/com/fleury/metrics/agent/model/Metric.java
+++ b/prometheus-metrics-agent-core/src/main/java/com/fleury/metrics/agent/model/Metric.java
@@ -80,27 +80,27 @@ public class Metric {
         private List<String> labels;
         private String mode;
 
-        public MetricBuilder withType(MetricType type) {
+        public MetricBuilder type(MetricType type) {
             this.type = type;
             return this;
         }
 
-        public MetricBuilder withName(String name) {
+        public MetricBuilder name(String name) {
             this.name = name;
             return this;
         }
 
-        public MetricBuilder withDoc(String doc) {
+        public MetricBuilder doc(String doc) {
             this.doc = doc;
             return this;
         }
 
-        public MetricBuilder withLabels(List<String> labels) {
+        public MetricBuilder labels(List<String> labels) {
             this.labels = labels;
             return this;
         }
 
-        public MetricBuilder withMode(String mode) {
+        public MetricBuilder mode(String mode) {
             this.mode = mode;
             return this;
         }

--- a/prometheus-metrics-agent-core/src/main/java/com/fleury/metrics/agent/reporter/PrometheusMetricSystem.java
+++ b/prometheus-metrics-agent-core/src/main/java/com/fleury/metrics/agent/reporter/PrometheusMetricSystem.java
@@ -114,9 +114,9 @@ public class PrometheusMetricSystem {
 
         new StandardExports().register();
 
-        addJVMMetrics(configuration);
+        addJvmMetrics(configuration);
 
-        addJMXScraper(configuration);
+        addJmxCollector(configuration);
     }
 
     public void startDefaultEndpoint() {
@@ -136,7 +136,7 @@ public class PrometheusMetricSystem {
         }
     }
 
-    private void addJMXScraper(Map<String, Object> configuration) {
+    private void addJmxCollector(Map<String, Object> configuration) {
         if (!configuration.containsKey("jmx")) {
             return;
         }
@@ -149,7 +149,7 @@ public class PrometheusMetricSystem {
         }
     }
 
-    private void addJVMMetrics(Map<String, Object> configuration) {
+    private void addJvmMetrics(Map<String, Object> configuration) {
         if (!configuration.containsKey("jvm")) {
             return;
         }

--- a/prometheus-metrics-agent-core/src/main/java/com/fleury/metrics/agent/reporter/PrometheusMetricSystem.java
+++ b/prometheus-metrics-agent-core/src/main/java/com/fleury/metrics/agent/reporter/PrometheusMetricSystem.java
@@ -121,7 +121,7 @@ public class PrometheusMetricSystem {
         startDefaultEndpoint();
     }
 
-    public void startDefaultEndpoint() {
+    private void startDefaultEndpoint() {
         Thread thread = new Thread(new Runnable() {
             @Override
             public void run() {

--- a/prometheus-metrics-agent-core/src/main/java/com/fleury/metrics/agent/reporter/PrometheusMetricSystem.java
+++ b/prometheus-metrics-agent-core/src/main/java/com/fleury/metrics/agent/reporter/PrometheusMetricSystem.java
@@ -117,23 +117,32 @@ public class PrometheusMetricSystem {
         addJvmMetrics(configuration);
 
         addJmxCollector(configuration);
+
+        startDefaultEndpoint();
     }
 
     public void startDefaultEndpoint() {
-        int port = DEFAULT_HTTP_PORT;
+        Thread thread = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                int port = DEFAULT_HTTP_PORT;
 
-        if (configuration.containsKey("httpPort")) {
-            port = Integer.parseInt((String)configuration.get("httpPort"));
-        }
+                if (configuration.containsKey("httpPort")) {
+                    port = Integer.parseInt((String)configuration.get("httpPort"));
+                }
 
-        try {
-            LOGGER.fine("Starting Prometheus HttpServer on port " + port);
+                try {
+                    LOGGER.fine("Starting Prometheus HttpServer on port " + port);
 
-            new HTTPServer(port);
+                    new HTTPServer(port);
 
-        } catch (Exception e) { //widen scope in case of ClassNotFoundException on non oracle/sun JVM
-            LOGGER.log(WARNING, "Unable to register Prometheus HttpServer on port " + port, e);
-        }
+                } catch (Exception e) { //widen scope in case of ClassNotFoundException on non oracle/sun JVM
+                    LOGGER.log(WARNING, "Unable to register Prometheus HttpServer on port " + port, e);
+                }
+            }
+        });
+        thread.setDaemon(true);
+        thread.start();
     }
 
     private void addJmxCollector(Map<String, Object> configuration) {

--- a/prometheus-metrics-agent-core/src/main/java/com/fleury/metrics/agent/transformer/asm/MetricAnnotationAttributeVisitor.java
+++ b/prometheus-metrics-agent-core/src/main/java/com/fleury/metrics/agent/transformer/asm/MetricAnnotationAttributeVisitor.java
@@ -23,7 +23,7 @@ public class MetricAnnotationAttributeVisitor extends AnnotationVisitor {
         this.config = config;
         this.metricKey = metricKey;
 
-        this.metricBuilder = Metric.builder().withType(metricType);
+        this.metricBuilder = Metric.builder().type(metricType);
     }
 
     @Override
@@ -31,9 +31,9 @@ public class MetricAnnotationAttributeVisitor extends AnnotationVisitor {
         super.visit(name, value);
 
         if ("name".equals(name)) {
-            metricBuilder.withName(value.toString());
+            metricBuilder.name(value.toString());
         } else if ("doc".equals(name)) {
-            metricBuilder.withDoc(value.toString());
+            metricBuilder.doc(value.toString());
         }
     }
 
@@ -42,7 +42,7 @@ public class MetricAnnotationAttributeVisitor extends AnnotationVisitor {
         super.visit(name, value);
 
         if ("mode".equals(name)) {
-            metricBuilder.withMode(value);
+            metricBuilder.mode(value);
         }
     }
 
@@ -51,7 +51,7 @@ public class MetricAnnotationAttributeVisitor extends AnnotationVisitor {
         if ("labels".equals(name)) {
 
             final List<String> labels = new ArrayList<String>();
-            metricBuilder.withLabels(labels);
+            metricBuilder.labels(labels);
 
             return new AnnotationVisitor(ASM5, av) {
 

--- a/prometheus-metrics-agent-core/src/main/java/com/fleury/metrics/agent/transformer/asm/StaticInitializerMethodVisitor.java
+++ b/prometheus-metrics-agent-core/src/main/java/com/fleury/metrics/agent/transformer/asm/StaticInitializerMethodVisitor.java
@@ -61,7 +61,8 @@ public class StaticInitializerMethodVisitor extends AdviceAdapter {
         // call PrometheusMetricSystem.createAndRegisterCounted/Timed/Gauged(...)
         super.visitMethodInsn(INVOKESTATIC, Type.getInternalName(PrometheusMetricSystem.class),
                 "createAndRegister" + metric.getType().name(),
-                Type.getMethodDescriptor(Type.getType(metric.getType().getPrometheusMetric()),
+                Type.getMethodDescriptor(
+                        Type.getType(metric.getType().getPrometheusMetric()),
                         Type.getType(String.class), Type.getType(String[].class), Type.getType(String.class)),
                 false);
 

--- a/prometheus-metrics-agent-core/src/test/java/com/fleury/metrics/agent/transformer/asm/injectors/CounterInjectorTest.java
+++ b/prometheus-metrics-agent-core/src/test/java/com/fleury/metrics/agent/transformer/asm/injectors/CounterInjectorTest.java
@@ -30,9 +30,9 @@ public class CounterInjectorTest extends BaseMetricTest {
     @Test
     public void shouldCountConstructorInvocationWithConfiguration() throws Exception {
         Metric meta = Metric.builder()
-                .withType(MetricType.Counted)
-                .withName("constructor")
-                .withLabels(Arrays.asList("label1:value1"))
+                .type(MetricType.Counted)
+                .name("constructor")
+                .labels(Arrays.asList("label1:value1"))
                 .createMetric();
 
         Configuration.Key key = new Configuration.Key(


### PR DESCRIPTION
Add JmxCollector support from https://github.com/prometheus/jmx_exporter

It obeys the exact same configuration and uses the jmx collector module. It means users can now instrument methods to add new metrics or scrape existing instrumented methods and metrics exposed via JMX